### PR TITLE
Added hash plugin (doc.hash = md5sum(doc.contents))

### DIFF
--- a/lettersmith-scm-1.rockspec
+++ b/lettersmith-scm-1.rockspec
@@ -24,11 +24,12 @@ description = {
 }
 dependencies = {
   "lua ~> 5.1",
-  "luafilesystem ~> 1.6.2",
+  "luafilesystem ~> 1.6",
   "lustache ~> 1.3",
-  "yaml ~> 1.1.1",
-  "lua-discount ~> 1.2.10.1",
-  "date ~> 2.1.1"
+  "yaml ~> 1.1",
+  "lua-discount ~> 1.2",
+  "date ~> 2.1",
+  "md5"
 }
 build = {
   type = "builtin",
@@ -45,6 +46,7 @@ build = {
     ["lettersmith.collections"] = "lettersmith/collections.lua",
     ["lettersmith.paging"] = "lettersmith/paging.lua",
     ["lettersmith.rss"] = "lettersmith/rss.lua",
+    ["lettersmith.hash"] = "lettersmith/hash.lua",
 
     -- Libraries
     ["lettersmith.foldable"] = "lettersmith/foldable.lua",

--- a/lettersmith.lua
+++ b/lettersmith.lua
@@ -1,4 +1,12 @@
-local exports = {}
+local exports = setmetatable({}, {
+  -- Transparently require submodules in the lettersmith namespace.
+  -- Exports of the module lettersmith still have priority.
+  -- Convenient for client/build scripts, not intended for modules.
+  __index = function(t,k)
+              local m = require("lettersmith."..k)
+              t[k] = m
+              return m
+            end})
 
 local foldable = require("lettersmith.foldable")
 local map = foldable.map
@@ -107,7 +115,7 @@ end
 -- Given `path_string` -- a path to a directory -- recursively walks through
 -- directory and returns a foldable of all file paths.
 -- Returns a foldable of file path strings.
-function walk_file_paths(path_string)
+local function walk_file_paths(path_string)
   return foldable.from_cps(walk_file_paths_cps, path_string)
 end
 exports.walk_file_paths = walk_file_paths

--- a/lettersmith/hash.lua
+++ b/lettersmith/hash.lua
@@ -1,0 +1,13 @@
+local map = require("lettersmith.foldable").map
+local extend = require("lettersmith.table_utils").extend
+local md5sum = require("md5").sumhexa
+
+return function (docs_foldable)
+  -- Add hash metadata field to all documents.
+  -- This field contains the 32 hexadecimal digits of the md5sum of the document contents.
+  -- Returns new list of documents with the md5 metadata field mixed in.
+  -- Fields from document take precedence.
+  return map(docs_foldable, function (doc)
+    return extend({ hash=md5sum(doc.contents) } , doc)
+  end)
+end


### PR DESCRIPTION
Also made some rockspec dependencies less strict.
This addresses #5.