### PR TITLE
Added various plugins (hash, serialize, debug).

### DIFF
--- a/debug.lua
+++ b/debug.lua
@@ -38,7 +38,7 @@ lettersmith.build("www", gen(paths))
 local exports = {}
 local serialize = require("lettersmith.serialize")
 local transducers = require("lettersmith.transducers")
-local comp2, reduce, id = transducers.comp2, transducers.reduce, transducers.id
+local comp, reduce, id = transducers.comp, transducers.reduce, transducers.id
 
 local function getname(n)
   return "Transformations left: "..n.."\n"
@@ -49,8 +49,12 @@ local function dbg_comp_filter(predicate, write_fn)
     local n_transforms = 0
     local function dbg_comp2(z_,y_)
       n_transforms = n_transforms + 1
-      return comp2(z_,comp2(serialize(getname(n_transforms),predicate,write_fn),y_))
+      return comp(z_,serialize(getname(n_transforms),predicate,write_fn),y_)
     end
+    -- Seed `id` is the last function in the pipeline, as the functions are
+    -- called in reverse order (right to left). The identity function closes
+    -- the chain to make sure the result of the last step of the pipeline is
+    -- also serialized.
     return reduce(dbg_comp2, id, ipairs{z or id, y, ...})
   end
 end

--- a/debug.lua
+++ b/debug.lua
@@ -1,0 +1,62 @@
+--[[
+Lettersmith Debug
+
+Debugging plugin for Lettersmith which provides a verbose version of
+`transducers.comp`. These functions insert a serialization xform between every
+pair of functions in the composed pipeline. This writes every doc object as it
+goes through each stage of the composed pipeline.
+
+Two functions are provided:
+
+comp_filter(predicate, write_fn)
+  This is a function which returns a debug version of `transducers.comp`, which
+  serializes:
+  * if `predicate` is a function: only the docs that pass `predicate` (default:
+    return true) or
+  * if `predicate` is a number: the first `predicate` docs.
+  The serialized docs are written using `write_fn` (default: io.write)
+  which could also be a collector, or could log the output to a file.
+
+comp(...)
+  This is the 'default' debug version of `comp`, which serializes every doc at
+  each pipeline stage and writes it to stdout.
+
+Example usage:
+-- [...]
+-- only print debugging info for the first doc 
+local comp = require("lettersmith.debug").comp_filter(1)
+
+local paths = lettersmith.paths("raw")
+local gen = comp(render_permalinks(":slug"),
+                 render_mustache("templates/page.html"),
+                 markdown,
+                 docs)
+lettersmith.build("www", gen(paths))
+
+--]]
+
+local exports = {}
+local serialize = require("lettersmith.serialize")
+local transducers = require("lettersmith.transducers")
+local comp2, reduce, id = transducers.comp2, transducers.reduce, transducers.id
+
+local function getname(n)
+  return "Transformations left: "..n.."\n"
+end 
+
+local function dbg_comp_filter(predicate, write_fn)
+  return function (z,y,...)
+    local n_transforms = 0
+    local function dbg_comp2(z_,y_)
+      n_transforms = n_transforms + 1
+      return comp2(z_,comp2(serialize(getname(n_transforms),predicate,write_fn),y_))
+    end
+    return reduce(dbg_comp2, id, ipairs{z or id, y, ...})
+  end
+end
+
+exports.comp_filter = dbg_comp_filter
+exports.comp = dbg_comp_filter() -- no filter, just a 'verbose' comp
+
+return exports
+

--- a/debug.lua
+++ b/debug.lua
@@ -41,8 +41,8 @@ lettersmith.build("www", gen(paths))
 --]]
 
 local exports = {}
-local serial = require("lettersmith.serialize")
-local serialize, serialize_diff = serial.serialize, serial.get_serialize_diff()
+local serialization = require("lettersmith.serialization")
+local serialize, serialize_diff = serialization.serialize, serialization.get_serialize_diff()
 local transducers = require("lettersmith.transducers")
 local comp, reduce, id = transducers.comp, transducers.reduce, transducers.id
 

--- a/hash.lua
+++ b/hash.lua
@@ -1,0 +1,15 @@
+--[[
+Lettersmith Hash
+
+Returns a transformer that fills in the 'hash' metadata field of a docs iterator.
+This field contains the 32 hexadecimal digits of the md5sum of the document contents.
+Fields from document take precedence.
+--]]
+local map = require("lettersmith.transducers").map
+local transformer = require("lettersmith.lazy").transformer
+local extend = require("lettersmith.table_utils").extend
+local md5sum = require("md5").sumhexa
+
+return transformer(map(function(doc)
+  return extend({ hash=md5sum(doc.contents) }, doc)
+end))

--- a/lettersmith-scm-1.rockspec
+++ b/lettersmith-scm-1.rockspec
@@ -27,7 +27,8 @@ dependencies = {
   "luafilesystem >= 1.6",
   "lustache >= 1.3",
   "yaml >= 1.1",
-  "lua-discount >= 1.2"
+  "lua-discount >= 1.2",
+  "md5"
 }
 build = {
   type = "builtin",
@@ -43,6 +44,7 @@ build = {
     ["lettersmith.rss"] = "rss.lua",
     ["lettersmith.paging"] = "paging.lua",
     ["lettersmith.format_date"] = "format_date.lua",
+    ["lettersmith.hash"] = "hash.lua",
 
     -- Libraries
     ["lettersmith.transducers"] = "transducers.lua",

--- a/lettersmith-scm-1.rockspec
+++ b/lettersmith-scm-1.rockspec
@@ -28,7 +28,8 @@ dependencies = {
   "lustache >= 1.3",
   "yaml >= 1.1",
   "lua-discount >= 1.2",
-  "md5"
+  "md5",
+  "serpent >= 0.25",
 }
 build = {
   type = "builtin",
@@ -45,6 +46,7 @@ build = {
     ["lettersmith.paging"] = "paging.lua",
     ["lettersmith.format_date"] = "format_date.lua",
     ["lettersmith.hash"] = "hash.lua",
+    ["lettersmith.serialize"] = "serialize.lua",
 
     -- Libraries
     ["lettersmith.transducers"] = "transducers.lua",

--- a/lettersmith-scm-1.rockspec
+++ b/lettersmith-scm-1.rockspec
@@ -46,7 +46,7 @@ build = {
     ["lettersmith.paging"] = "paging.lua",
     ["lettersmith.format_date"] = "format_date.lua",
     ["lettersmith.hash"] = "hash.lua",
-    ["lettersmith.serialize"] = "serialize.lua",
+    ["lettersmith.serialization"] = "serialization.lua",
     ["lettersmith.debug"] = "debug.lua",
 
     -- Libraries

--- a/lettersmith-scm-1.rockspec
+++ b/lettersmith-scm-1.rockspec
@@ -47,6 +47,7 @@ build = {
     ["lettersmith.format_date"] = "format_date.lua",
     ["lettersmith.hash"] = "hash.lua",
     ["lettersmith.serialize"] = "serialize.lua",
+    ["lettersmith.debug"] = "debug.lua",
 
     -- Libraries
     ["lettersmith.transducers"] = "transducers.lua",

--- a/serialization.lua
+++ b/serialization.lua
@@ -1,5 +1,5 @@
 --[[
-Lettersmith Serialize
+Lettersmith Serialization
 
 Serialization plugin for Lettersmith. Useful for debugging.
 
@@ -26,8 +26,8 @@ get_serialize_diff()
 Example usage:
 
 -- [...]
-local serialize = require("lettersmith.serialize").serialize
-local diff = require("lettersmith.serialize").get_serialize_diff()
+local serialize = require("lettersmith.serialization").serialize
+local diff = require("lettersmith.serialization").get_serialize_diff()
 
 local paths = lettersmith.paths("raw")
 local gen = comp(serialize("final_doc = "),

--- a/serialize.lua
+++ b/serialize.lua
@@ -3,33 +3,51 @@ Lettersmith Serialize
 
 Serialization plugin for Lettersmith. Useful for debugging.
 
-This function takes three arguments:
- - `info_string`: to be written at the top of each serialization (default: "")
- - `predicate`: a predicate function (default: return true)
- or 
-   `n`: number of docs that should be serialized
- - `write_fn`: function that is called with the serialized doc string as
- argument (default: io.write).
- 
-This function returns a transformer that serializes and writes the documents
-that pass `predicate`, but does not change them.
+Two functions are provided:
+
+serialize(info_string, predicate, write_fn)
+  This function takes three arguments:
+  - `info_string`: to be written at the top of each serialization (default: "")
+  - `predicate`: a predicate function (default: return true) 
+   OR the number of docs that should be serialized (the first `predicate` docs)
+  - `write_fn`: function that is called with the serialized doc string as
+    argument (default: io.write).
+  This function returns a transformer that serializes and writes the documents
+  that pass `predicate`, but does not change them.
+
+get_serialize_diff()
+  This returns a stateful serialize_diff function which serializes only the
+  difference between the current doc table and the one in the previous use of
+  this serialize_diff in the pipeline. To do this, it keeps track of the
+  previous doc. In addition to the arguments of the serialize function, it
+  takes an optional `reset` flag (default: false) to indicate the end of the
+  pipeline, in which case its state is reset _after_ the write.
+
 --]]
 
+local exports = {}
 local map = require("lettersmith.transducers").map
 local transformer = require("lettersmith.lazy").transformer
 local serpent = require("serpent")
 local serpent_opts = {comment=false, nocode=true,}
-local serialize_n
-local function allpass()
-  return true
+local function allpass() return true end
+
+-- If `predicate` is a number, `make_predicate` returns a function that
+-- counts down from `predicate` and returns true `predicate` times.
+-- Otherwise, return `predicate`, or if this is falsy, return allpass.
+local function make_predicate(predicate)
+  if type(predicate)=="number" then
+    return function()
+      predicate = predicate-1
+      return predicate>=0
+    end
+  end
+  return predicate or allpass
 end
 
 local function serialize(info_string, predicate, write_fn)
-  if type(predicate)=="number" then
-    return serialize_n(info_string, predicate, write_fn)
-  end
   info_string = info_string or ""
-  predicate = predicate or allpass
+  predicate = make_predicate(predicate)
   write_fn = write_fn or io.write
   return transformer(map(function(doc)
     if predicate(doc) then
@@ -38,15 +56,44 @@ local function serialize(info_string, predicate, write_fn)
     return doc
   end))
 end
+exports.serialize = serialize
 
-function serialize_n(info_string, n, write_fn)
-  n = n or 1
-  local function first_n()
-    n = n-1
-    return n>=0
+-- `diff` returns a table which summarizes the differences between t1 and t2.
+local function diff(t1,t2)
+  local t_diff = {}
+  for k,v in pairs(t2) do
+    if v~=t1[k] then
+      t_diff[k]=v
+    end
   end
-  return serialize(info_string, first_n, write_fn)
+  for k in pairs(t1) do
+    if not t2[k] then
+      t_diff[k]= "<removed>"
+    end
+  end
+  return t_diff
 end
 
-return serialize
+-- Get a stateful function for serializing diffs.
+local function get_serialize_diff()
+  local doc_prev = {}
+  return function(info_string, predicate, write_fn, reset)
+    info_string = info_string or ""
+    predicate = make_predicate(predicate)
+    write_fn = write_fn or io.write
+    return transformer(map(function(doc)
+      if predicate(doc) then
+        local doc_diff = diff(doc_prev,doc)
+        write_fn(info_string,serpent.block(doc_diff,serpent_opts).."\n")
+        doc_prev = doc
+      end
+      if reset then doc_prev = {} end
+      return doc
+    end))
+  end
+end
+exports.get_serialize_diff = get_serialize_diff
+
+return exports
+
 

--- a/serialize.lua
+++ b/serialize.lua
@@ -23,6 +23,24 @@ get_serialize_diff()
   takes an optional `reset` flag (default: false) to indicate the end of the
   pipeline, in which case its state is reset _after_ the write.
 
+Example usage:
+
+-- [...]
+local serialize = require("lettersmith.serialize").serialize
+local diff = require("lettersmith.serialize").get_serialize_diff()
+
+local paths = lettersmith.paths("raw")
+local gen = comp(serialize("final_doc = "),
+                 render_permalinks(":slug"),
+                 render_mustache("templates/page.html"),
+                 diff("diff_markdown_and_hash = ",nil,nil,true),
+                 markdown,
+                 hash,
+                 diff("beginning = "),
+                 docs)
+
+lettersmith.build("www", gen(paths))
+
 --]]
 
 local exports = {}

--- a/serialize.lua
+++ b/serialize.lua
@@ -1,0 +1,52 @@
+--[[
+Lettersmith Serialize
+
+Serialization plugin for Lettersmith. Useful for debugging.
+
+This function takes three arguments:
+ - `info_string`: to be written at the top of each serialization (default: "")
+ - `predicate`: a predicate function (default: return true)
+ or 
+   `n`: number of docs that should be serialized
+ - `write_fn`: function that is called with the serialized doc string as
+ argument (default: io.write).
+ 
+This function returns a transformer that serializes and writes the documents
+that pass `predicate`, but does not change them.
+--]]
+
+local map = require("lettersmith.transducers").map
+local transformer = require("lettersmith.lazy").transformer
+local serpent = require("serpent")
+local serpent_opts = {comment=false, nocode=true,}
+local serialize_n
+local function allpass()
+  return true
+end
+
+local function serialize(info_string, predicate, write_fn)
+  if type(predicate)=="number" then
+    return serialize_n(info_string, predicate, write_fn)
+  end
+  info_string = info_string or ""
+  predicate = predicate or allpass
+  write_fn = write_fn or io.write
+  return transformer(map(function(doc)
+    if predicate(doc) then
+      write_fn(info_string,serpent.block(doc,serpent_opts).."\n")
+    end
+    return doc
+  end))
+end
+
+function serialize_n(info_string, n, write_fn)
+  n = n or 1
+  local function first_n()
+    n = n-1
+    return n>=0
+  end
+  return serialize(info_string, first_n, write_fn)
+end
+
+return serialize
+


### PR DESCRIPTION
The `hash` plugin adds a hash field to the doc table.
The `debug` and `serialization` plugins allow the user to monitor the state of the `doc` table as it moves through the pipeline. This can be quite helpful for troubleshooting, and to find out how the various plugins work. There are `diff` variants of the functions which only show the changed/removed fields.
`debug` provides "verbose"  compose functions, which write the result of every stage in the pipeline created by these. More targeted monitoring can be done with the `serialization` functions (which also include a diff-variant).